### PR TITLE
Fix Gardevan lightregen effect

### DIFF
--- a/scripts/raceEffects.lua
+++ b/scripts/raceEffects.lua
@@ -190,7 +190,7 @@ function update(dt)
 	if world.entitySpecies(entity.id()) == "gardevan" then
 		status.addEphemeralEffect("racegardevan",math.huge)
 		status.addEphemeralEffect("lighthunter",math.huge)
-		status.addEphemeralEffect("lightregen",math.huge)
+		status.addEphemeralEffect("lightregenfloran",math.huge)
 		
 	end
 	--Wasp Hive


### PR DESCRIPTION
The game complains about not finding the `lightregen` effect, which seems to render Gardevan characters immune to all damage.  Looking back in the commit history, the race used to use `lightregenfloran`, and using that effect fixes the issue.