### PR TITLE
Fix for whipcrack issue

### DIFF
--- a/items/active/weapons/whip/abilities/whipcrack.lua
+++ b/items/active/weapons/whip/abilities/whipcrack.lua
@@ -230,8 +230,8 @@ function WhipCrack:findAnchor()
     local anchorValid = nil
     for _, anchorObject in pairs(objectsNearCursor) do
       local objectName = world.entityName(anchorObject)
-      local objectConfig = { pcall(root.itemConfig, objectName) } -- want [1]=true, [2]=config
-      if objectConfig[1] == true and objectConfig[2].config.category == "light" then
+      local objectConfig = root.itemConfig(objectName)
+      if objectConfig and objectConfig.config.category == "light" then
         anchorValid = anchorObject
         break
       end


### PR DESCRIPTION
shouldn't crash when holding down fire near an item it can't get the
config from anymore

fix by cat2002