### PR TITLE
Fix for duplicate in quickbar

### DIFF
--- a/quickbar/icons.json.patch
+++ b/quickbar/icons.json.patch
@@ -1,5 +1,10 @@
-
 [
+	{
+		"op" : "test",
+		"path" : "/normal/0/label",
+		"value" : "Character Status",
+		"inverse" : true
+	},
 	{
 		"op": "add",
 		"path": "/normal/0",


### PR DESCRIPTION
Adds a test to see if FU already added the Character Status button, preventing two of the same button from appearing in the Quickbar.
It should work fine as long as no other mods specifically add a button to index 0 between when Frackin' Universe and Frackin' Races load somehow.