### PR TITLE
Robot Food Sickness Increased

### DIFF
--- a/stats/effects/food/robofood.lua
+++ b/stats/effects/food/robofood.lua
@@ -36,6 +36,8 @@ function applyPenalty()
 	sourceEntityId = entity.id()
       })
       effect.setParentDirectives("fade=806e4f="..self.tickTimer * 0.25) 
+	status.removeEphemeralEffect("wellfed")
+	if status.resourcePercentage("food") > 0.85 then status.setResourcePercentage("food", 0.85) end
 end
 
 function applyEffects()


### PR DESCRIPTION
Eating robot food without being a robot will now cap your hunger at 85%
and forcibly remove Full Belly while in effect
Suck it, organics.