### PR TITLE
Moogle Update

### DIFF
--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -2384,9 +2384,13 @@
 				"stat": "fallDamageMultiplier",
 				"baseMultiplier": 0.5
 			},
-			{
-				"stat": "grit",
-				"amount": -0.2
+            {
+				"stat" : "physicalResistance",
+				"amount" : -0.1
+			},
+            {
+				"stat" : "cosmicResistance",
+				"amount" : 0.1
 			}
 		],
 
@@ -2401,11 +2405,11 @@
 			"args": {
 				"stats": [{
 						"stat": "powerMultiplier",
-						"amount": 0.05
+						"amount": 0.1
 					},
 					{
-						"stat": "critBonus",
-						"amount": 5
+						"stat": "critChance",
+						"amount": 3
 					}
 				]
 			}

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -9,7 +9,7 @@
     
     ^red;Weakness: Bad swimmers, -20% Life, -10% Physical Resist^reset;
     ^green;Strength: +10% Speed, +20% Energy, Gliding, Halved Fall Damage, +10% Cosmic Resist^reset;
-    Guns: ^green;+10% Damage, +5 Crit. Chance^reset;
+    Guns: ^green;+10% Damage, +3 Crit^reset;
     Built-In: ^green;Extra upgraded mech body.^reset;"
     }
 ]

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -7,9 +7,9 @@
     "path" : "/charCreationTooltip/description" , 
     "value" : "Adorable, fluffy lagomorphic critters from a distant world of fantasy that have a pom-pom, bat wings and a thing for saying \"Kupo!\". They are usually machinists, but on occasion, they become knights or mages instead.
     
-    ^red;Weakness: Bad swimmers, -20% Life, +20% Knockback Taken^reset;
-    ^green;Strength: +10% Speed, +20% Energy, Gliding, Halved Fall Damage^reset;
-    Guns: ^green;+5% Damage, +5 Crit. Damage^reset;
+    ^red;Weakness: Bad swimmers, -20% Life, -10% Physical Resist^reset;
+    ^green;Strength: +10% Speed, +20% Energy, Gliding, Halved Fall Damage, +10% Cosmic Resist^reset;
+    Guns: ^green;+10% Damage, +5 Crit. Chance^reset;
     Built-In: ^green;Extra upgraded mech body.^reset;"
     }
 ]


### PR DESCRIPTION
> Buffed gun damage by **5%**, making it **10%**
> Replaced knockback weakness with **10% physical weakness/fragility and cosmic resistance**, closer to FF Tactics Advance/A2 stats.
> Replaced _+5% Crit Damage_ with **+3 Crit Chance**.