### PR TITLE
Moogle Tweaks

### DIFF
--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -2579,7 +2579,7 @@
 			]
 		}]
 	},
-	"aerialEffect": {
+		"aerialEffect": {
 		"fallStats": {
 			"controlParameters": {
 				"airForce": 40,
@@ -2604,6 +2604,7 @@
 				}
 			}
 		}
+	}
 	},
     "vulpes" : {
         "stats" : [

--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -2582,7 +2582,7 @@
 	"aerialEffect": {
 		"fallStats": {
 			"controlParameters": {
-				"airForce": 45,
+				"airForce": 40,
 				"runSpeed": 16,
 				"walkSpeed": 16
 			},

--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -2518,30 +2518,38 @@
 			},
 			{
 				"stat": "fallDamageMultiplier",
-				"baseMultiplier": 0.5
+				"baseMultiplier": 0.25
 			},
 			{
-				"stat" : "physicalResistance",
-				"amount" : -0.1
+				"stat": "physicalResistance",
+				"amount": -0.05
 			},
 			{
-				"stat" : "cosmicResistance",
-				"amount" : 0.2
+				"stat": "cosmicResistance",
+				"amount": 0.25
 			},
 			{
-				"stat" : "shadowResistance",
-				"amount" : -0.1
+				"stat": "shadowResistance",
+				"amount": -0.15
 			},
 			{
-				"stat" : "fuCharisma",
-				"amount" : 5
+				"stat": "radioactiveResistance",
+				"amount": -0.05
+			},
+			{
+				"stat": "fuCharisma",
+				"amount": 5
+			},
+			{
+				"stat": "jungleslowImmunity",
+				"amount": 1
 			}
 		],
 
 		"controlModifiers": {
-			"speedModifier": 1.1,
-			"airJumpModifier": 1.09,
-			"liquidForce": 40.0
+			"speedModifier": 1.15,
+			"airJumpModifier": 1.125,
+			"liquidForce": 50.0
 		},
 		"weaponScripts": [{
 			"script": "/scripts/fr_weaponscripts/freebonus.lua",
@@ -2558,29 +2566,41 @@
 				]
 			}
 		}],
-		"aerialEffect": {
-			"fallStats": {
-				"controlParameters": {
-					"airForce": 40,
-					"runSpeed": 16,
-					"walkSpeed": 16
+		"weaponEffects": [{
+			"weapons": ["rapier", "energy", "wand", "staff"],
+			"stats": [{
+					"stat": "powerMultiplier",
+					"baseMultiplier": 1.05
 				},
-				"maxFallSpeed": -39
+				{
+					"stat": "critChance",
+					"amount": 1
+				}
+			]
+		}]
+	},
+	"aerialEffect": {
+		"fallStats": {
+			"controlParameters": {
+				"airForce": 45,
+				"runSpeed": 16,
+				"walkSpeed": 16
 			},
-			"windEffects": {
-				"windLow": {
-					"speed": 70,
-					"controlModifiers": {
-						"speedModifier": 1.12,
-						"airJumpModifier": 1.12
-					}
-				},
-				"windHigh": {
-					"speed": 7,
-					"controlModifiers": {
-						"speedModifier": 1.20,
-						"airJumpModifier": 1.20
-					}
+			"maxFallSpeed": -39
+		},
+		"windEffects": {
+			"windLow": {
+				"speed": 70,
+				"controlModifiers": {
+					"speedModifier": 1.12,
+					"airJumpModifier": 1.12
+				}
+			},
+			"windHigh": {
+				"speed": 7,
+				"controlModifiers": {
+					"speedModifier": 1.20,
+					"airJumpModifier": 1.20
 				}
 			}
 		}

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -10,7 +10,7 @@
     ^red;Weakness: -20% Life, -5% Physical Resist, -5% Radioactive Resist, -15% Shadow Resist^reset;
     ^green;Strength: +10% Speed, +20% Energy, +20% Cosmic Resist^reset;
     ^yellow;Effects: ^green;Adorable, Quarter Fall Damage
-    ^blue;Movement: ^green;Gliding, ^red;Bad swimmers^reset;
+    ^blue;Movement: ^green;Gliding, Increased Agility, ^red;Bad swimmers^reset;
     ^orange;Combat: Firearms gain ^green;+10% Damage, +3 Crit^reset;
     ^orange;Rapiers, Energy Weapons, Staves and Wands gain ^green;+5% Damage, +1 Crit^reset;
     ^violet;Built-In: ^green;Extra craftable racial mech body tier.^reset;"

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -7,10 +7,12 @@
     "path" : "/charCreationTooltip/description" , 
     "value" : "Adorable, fluffy, cosmic-attuned lagomorphic critters from a distant world of fantasy that have a pom-pom, bat wings and a thing for saying \"Kupo!\". They are usually expert machinists, but on occasion, they may become a knight or a mage instead.
     
-    ^red;Weakness: Bad swimmers, -20% Life, -10% Physical Resist, -10% Shadow Resist^reset;
+    ^red;Weakness: -20% Life, -5% Physical Resist, -5% Radioactive Resist, -15% Shadow Resist^reset;
     ^green;Strength: +10% Speed, +20% Energy, +20% Cosmic Resist^reset;
-    ^yellow;Effects: ^green;Charismatic, Gliding, Half Fall Damage^reset;
-    ^orange;Combat: All guns gain ^green;+10% Damage, +3 Crit^reset;
-    ^violet;Built-In: ^green;Extra upgraded mech body.^reset;"
+    ^yellow;Effects: ^green;Adorable, Quarter Fall Damage
+    ^blue;Movement: ^green;Gliding, ^red;Bad swimmers^reset;
+    ^orange;Combat: Firearms gain ^green;+10% Damage, +3 Crit^reset;
+    ^orange;Rapiers, Energy Weapons, Staves and Wands gain ^green;+5% Damage, +1 Crit^reset;
+    ^violet;Built-In: ^green;Extra craftable racial mech body tier.^reset;"
     }
 ]


### PR DESCRIPTION
STATS
- Fall Damage is now quartered

ELEMENTAL RESISTANCES
- Physical: +5% damage recieved (Was +10%)
- Radioactive: +5% damage recieved (Was 0%)
- Shadow: +15% damage recieved (Was +10%)
- Cosmic: -25% damage recieved (Was -20%)

MOVEMENT
- Agility buffed, including air and water.
- Nullifies jungle tile effects

WEAPONS
- Rapiers, Energy Weapons, Staves and Wands do +5% damage and +1% crit. rate