### PR TITLE
Moogle Tweaks II

### DIFF
--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -2503,110 +2503,124 @@
         ]
     },
 
-"moogle": 	{
+"moogle": {
+	"stats": [{
+			"stat": "isOmnivore",
+			"amount": 1
+		},
+		{
+			"stat": "maxHealth",
+			"baseMultiplier": 0.80
+		},
+		{
+			"stat": "maxEnergy",
+			"baseMultiplier": 1.20
+		},
+		{
+			"stat": "fallDamageMultiplier",
+			"baseMultiplier": 0.4
+		},
+		{
+			"stat": "physicalResistance",
+			"amount": -0.2
+		},
+		{
+			"stat": "electricResistance",
+			"amount": 0.2
+		},
+		{
+			"stat": "cosmicResistance",
+			"amount": 0.2
+		},
+		{
+			"stat": "shadowResistance",
+			"amount": -0.1
+		},
+		{
+			"stat": "radioactiveResistance",
+			"amount": -0.1
+		},
+		{
+			"stat": "fuCharisma",
+			"amount": 5
+		}
+	],
+	"weaponEffects": [{
+		"weapons": ["broadsword", "shortsword", "staff", "wand"],
 		"stats": [{
-				"stat": "isOmnivore",
+			"stat": "powerMultiplier",
+			"baseMultiplier": 1.05
+		}]
+	}, {
+		"weapons": ["pistol", "machinepistol", "rapier", "spear"],
+		"stats": [{
+				"stat": "powerMultiplier",
+				"baseMultiplier": 1.1
+			},
+			{
+				"stat": "critChance",
 				"amount": 1
-			},
-			{
-				"stat": "maxHealth",
-				"baseMultiplier": 0.80
-			},
-			{
-				"stat": "maxEnergy",
-				"baseMultiplier": 1.20
-			},
-			{
-				"stat": "fallDamageMultiplier",
-				"baseMultiplier": 0.4
-			},
-			{
-				"stat": "physicalResistance",
-				"amount": -0.05
-			},
-			{
-				"stat": "cosmicResistance",
-				"amount": 0.3
-			},
-			{
-				"stat": "shadowResistance",
-				"amount": -0.2
-			},
-			{
-				"stat": "radioactiveResistance",
-				"amount": -0.05
-			},
-			{
-				"stat": "fuCharisma",
-				"amount": 5
 			}
-		],
-		"weaponEffects": [{
-			"weapons": ["broadsword", "shortsword", "staff", "wand"],
-			"stats": [{
+		]
+	}, {
+		"weapons": ["energy"],
+		"stats": [{
 				"stat": "powerMultiplier",
 				"baseMultiplier": 1.05
-			}]
-		}, {
-			"weapons": ["energy", "rapier", "spear", "pistol", "machinepistol"],
+			},
+			{
+				"stat": "critChance",
+				"amount": 2
+			}
+		]
+	}],
+	"controlModifiers": {
+		"speedModifier": 1.1,
+		"airJumpModifier": 1.1,
+		"liquidForce": 40.0
+	},
+	"weaponScripts": [{
+		"script": "/scripts/fr_weaponscripts/freebonus.lua",
+		"contexts": ["gun-init"],
+		"args": {
 			"stats": [{
 					"stat": "powerMultiplier",
-					"baseMultiplier": 1.1
+					"amount": 0.05
 				},
 				{
 					"stat": "critChance",
-					"amount": 2
+					"amount": 1
 				}
 			]
-		}],
-		"controlModifiers": {
-			"speedModifier": 1.1,
-			"airJumpModifier": 1.1,
-			"liquidForce": 40.0
-		},
-		"weaponScripts": [{
-			"script": "/scripts/fr_weaponscripts/freebonus.lua",
-			"contexts": ["gun-init"],
-			"args": {
-				"stats": [{
-						"stat": "powerMultiplier",
-						"amount": 0.05
-					},
-					{
-						"stat": "critChance",
-						"amount": 1
-					}
-				]
-			}
-		}],
-
-		"aerialEffect": {
-			"fallStats": {
-				"controlParameters": {
-					"airForce": 40,
-					"runSpeed": 16,
-					"walkSpeed": 16
-				},
-				"maxFallSpeed": -39
+		}
+	}],
+	"aerialEffect": {
+		"fallStats": {
+			"controlParameters": {
+				"airForce": 40,
+				"runSpeed": 16,
+				"walkSpeed": 16
 			},
-			"windEffects": {
-				"windLow": {
-					"speed": 70,
-					"controlModifiers": {
-						"speedModifier": 1.12,
-						"airJumpModifier": 1.12
-					}
-				},
-				"windHigh": {
-					"speed": 7,
-					"controlModifiers": {
-						"speedModifier": 1.20,
-						"airJumpModifier": 1.20
-					}
+			"maxFallSpeed": -39
+		},
+		"windEffects": {
+			"windLow": {
+				"speed": 70,
+				"controlModifiers": {
+					"speedModifier": 1.12,
+					"airJumpModifier": 1.12
+				}
+			},
+			"windHigh": {
+				"speed": 7,
+				"controlModifiers": {
+					"speedModifier": 1.20,
+					"airJumpModifier": 1.20
 				}
 			}
 		}
-	},
+	}
+},
     "vulpes" : {
         "stats" : [
             { "stat" : "isCarnivore", "amount" : 1 },

--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -2503,7 +2503,7 @@
         ]
     },
 
-"moogle": {
+"moogle": 	{
 		"stats": [{
 				"stat": "isOmnivore",
 				"amount": 1
@@ -2521,45 +2521,44 @@
 				"baseMultiplier": 0.4
 			},
 			{
-				"stat" : "physicalResistance",
-				"amount" : -0.05
+				"stat": "physicalResistance",
+				"amount": -0.05
 			},
 			{
-				"stat" : "cosmicResistance",
-				"amount" : 0.3
+				"stat": "cosmicResistance",
+				"amount": 0.3
 			},
 			{
-				"stat" : "shadowResistance",
-				"amount" : -0.15
+				"stat": "shadowResistance",
+				"amount": -0.2
 			},
 			{
-				"stat" : "radioactiveResistance"
-				"amount" : -0.1
+				"stat": "radioactiveResistance",
+				"amount": -0.05
 			},
 			{
-				"stat" : "fuCharisma",
-				"amount" : 5
+				"stat": "fuCharisma",
+				"amount": 5
 			}
 		],
-        "weaponEffects" : [
-                "weapons" : ["broadsword", "shortsword", "staff", "wand"],
-                "stats" : [
-					{
-						"stat": "powerMultiplier",
-						"amount": 0.05
-					}
-		],
-				"weapons" : ["energy", "rapier", "spear", "pistol", "machinepistol"],
-				"stats" : [
-					{
-						"stat": "powerMultiplier",
-						"amount": 0.1
-					},
-					{
-						"stat": "critChance",
-						"amount": 2
-					}
-				]]
+		"weaponEffects": [{
+			"weapons": ["broadsword", "shortsword", "staff", "wand"],
+			"stats": [{
+				"stat": "powerMultiplier",
+				"baseMultiplier": 1.05
+			}]
+		}, {
+			"weapons": ["energy", "rapier", "spear", "pistol", "machinepistol"],
+			"stats": [{
+					"stat": "powerMultiplier",
+					"baseMultiplier": 1.1
+				},
+				{
+					"stat": "critChance",
+					"amount": 2
+				}
+			]
+		}],
 		"controlModifiers": {
 			"speedModifier": 1.1,
 			"airJumpModifier": 1.1,
@@ -2580,7 +2579,7 @@
 				]
 			}
 		}],
-		
+
 		"aerialEffect": {
 			"fallStats": {
 				"controlParameters": {

--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -2518,18 +2518,22 @@
 			},
 			{
 				"stat": "fallDamageMultiplier",
-				"baseMultiplier": 0.5
+				"baseMultiplier": 0.4
 			},
 			{
 				"stat" : "physicalResistance",
-				"amount" : -0.1
+				"amount" : -0.05
 			},
 			{
 				"stat" : "cosmicResistance",
-				"amount" : 0.2
+				"amount" : 0.3
 			},
 			{
 				"stat" : "shadowResistance",
+				"amount" : -0.15
+			},
+			{
+				"stat" : "radioactiveResistance"
 				"amount" : -0.1
 			},
 			{
@@ -2537,10 +2541,28 @@
 				"amount" : 5
 			}
 		],
-
+        "weaponEffects" : [
+                "weapons" : ["broadsword", "shortsword", "staff", "wand"],
+                "stats" : [
+					{
+						"stat": "powerMultiplier",
+						"amount": 0.05
+					}
+		],
+				"weapons" : ["energy", "rapier", "spear", "pistol", "machinepistol"],
+				"stats" : [
+					{
+						"stat": "powerMultiplier",
+						"amount": 0.1
+					},
+					{
+						"stat": "critChance",
+						"amount": 2
+					}
+				]]
 		"controlModifiers": {
 			"speedModifier": 1.1,
-			"airJumpModifier": 1.09,
+			"airJumpModifier": 1.1,
 			"liquidForce": 40.0
 		},
 		"weaponScripts": [{
@@ -2549,15 +2571,16 @@
 			"args": {
 				"stats": [{
 						"stat": "powerMultiplier",
-						"amount": 0.1
+						"amount": 0.05
 					},
 					{
 						"stat": "critChance",
-						"amount": 3
+						"amount": 1
 					}
 				]
 			}
 		}],
+		
 		"aerialEffect": {
 			"fallStats": {
 				"controlParameters": {

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -7,13 +7,13 @@
     "path" : "/charCreationTooltip/description" , 
     "value" : "Adorable, fluffy, cosmic-attuned lagomorphic critters from a distant world of fantasy that have a pom-pom, bat wings and a thing for saying \"Kupo!\". They are usually expert machinists, but on occasion, they may become a knight or a mage instead.
     
-    ^red;-20% Life, -5% Physical, -15% Shadow, -10% Radioactive Resistances^reset;
-    ^green;+20% Energy, +30% Cosmic Resistance^reset;
+    ^red;-20% Life, -20% Physical, -10% Shadow and Radioactive Resistances^reset;
+    ^green;+20% Energy, +20% Electric and Cosmic Resistances^reset;
     ^green;Adorable, 40% Fall Damage^reset;
     ^cyan;Gliding, ^green;+10% Speed and Jump, ^red;Bad at swimming^reset;
     ^magenta;Extra craftable mech body.^reset;
     ^yellow;Firearms gain ^green;+5% Damage, +1% Crit^reset;
-    ^yellow;Broadswords, Shortswords, Staves and Wands gain ^green;+5% damage^reset;
-    ^yellow;Rapiers, Spears, Energy Weapons, Pistols and Machine Pistols gain ^green;+10% damage, +2% Crit^reset;"
+    ^yellow;Broadswords, Shortswords, Staves and Wands gain ^green;5% damage^reset;
+    ^yellow;Rapiers, Spears, Energy Weapons, Pistols and Machine Pistols gain ^green;10% damage, +2% Crit^reset;"
     }
 ]

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -14,6 +14,6 @@
     ^magenta;Extra craftable mech body.^reset;
     ^yellow;Firearms gain ^green;+5% Damage, +1% Crit^reset;
     ^yellow;Broadswords, Shortswords, Staves and Wands gain ^green;5% damage^reset;
-    ^yellow;Rapiers, Spears, Energy, Pistols and Machine Pistols gain ^green;10% damage, +2% Crit^reset;"
+    ^yellow;Rapiers, Spears, Energy Weapons, Pistols and Machine Pistols gain ^green;10% damage, +2% Crit^reset;"
     }
 ]

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -13,7 +13,8 @@
     ^cyan;Gliding, ^green;+10% Speed and Jump, ^red;Bad at swimming^reset;
     ^magenta;Extra craftable mech body.^reset;
     ^yellow;Firearms gain ^green;+5% Damage, +1% Crit^reset;
-    ^yellow;Broadswords, Shortswords, Staves and Wands gain ^green;5% damage^reset;
-    ^yellow;Rapiers, Spears, Energy Weapons, Pistols and Machine Pistols gain ^green;10% damage, +2% Crit^reset;"
+    ^yellow;Broadswords, Shortswords, Staves, and Wands gain ^green;+5% damage^reset;
+    ^yellow;Rapiers, Spears, Pistols and Machine Pistols gain ^green;+10% damage, +1% Crit^reset;
+    ^yellow;Energy Weapons gain ^green;+5% damage, +2% Crit^reset;"
     }
 ]

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -7,10 +7,13 @@
     "path" : "/charCreationTooltip/description" , 
     "value" : "Adorable, fluffy, cosmic-attuned lagomorphic critters from a distant world of fantasy that have a pom-pom, bat wings and a thing for saying \"Kupo!\". They are usually expert machinists, but on occasion, they may become a knight or a mage instead.
     
-    ^red;Weakness: Bad swimmers, -20% Life, -10% Physical Resist, -10% Shadow Resist^reset;
-    ^green;Strength: +10% Speed, +20% Energy, +20% Cosmic Resist^reset;
-    ^yellow;Effects: ^green;Charismatic, Gliding, Half Fall Damage^reset;
-    ^orange;Combat: All guns gain ^green;+10% Damage, +3 Crit^reset;
-    ^violet;Built-In: ^green;Extra upgraded mech body.^reset;"
+    ^red;-20% Life, -5% Physical, -15% Shadow, -10% Radioactive Resistances^reset;
+    ^green;+10% Speed, +20% Energy, +30% Cosmic Resistance^reset;
+    ^green;Adorable, 40% Fall Damage^reset;
+    ^cyan;Gliding, ^green;+10% Speed and Jump, ^red;Bad at swimming^reset;
+    ^magenta;Extra craftable mech body.^reset;
+    ^yellow;Firearms gain ^green;+5% Damage, +1% Crit^reset;
+    ^yellow;Broadswords, Shortswords, Staves and Wands gain ^green;5% damage^reset;
+    ^yellow;Rapiers, Spears, Energy, Pistols and Machine Pistols gain ^green;10% damage, +2% Crit^reset;"
     }
 ]

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -8,7 +8,7 @@
     "value" : "Adorable, fluffy, cosmic-attuned lagomorphic critters from a distant world of fantasy that have a pom-pom, bat wings and a thing for saying \"Kupo!\". They are usually expert machinists, but on occasion, they may become a knight or a mage instead.
     
     ^red;-20% Life, -5% Physical, -15% Shadow, -10% Radioactive Resistances^reset;
-    ^green;+10% Speed, +20% Energy, +30% Cosmic Resistance^reset;
+    ^green;+20% Energy, +30% Cosmic Resistance^reset;
     ^green;Adorable, 40% Fall Damage^reset;
     ^cyan;Gliding, ^green;+10% Speed and Jump, ^red;Bad at swimming^reset;
     ^magenta;Extra craftable mech body.^reset;

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -13,7 +13,7 @@
     ^cyan;Gliding, ^green;+10% Speed and Jump, ^red;Bad at swimming^reset;
     ^magenta;Extra craftable mech body.^reset;
     ^yellow;Firearms gain ^green;+5% Damage, +1% Crit^reset;
-    ^yellow;Broadswords, Shortswords, Staves and Wands gain ^green;5% damage^reset;
-    ^yellow;Rapiers, Spears, Energy Weapons, Pistols and Machine Pistols gain ^green;10% damage, +2% Crit^reset;"
+    ^yellow;Broadswords, Shortswords, Staves and Wands gain ^green;+5% damage^reset;
+    ^yellow;Rapiers, Spears, Energy Weapons, Pistols and Machine Pistols gain ^green;+10% damage, +2% Crit^reset;"
     }
 ]


### PR DESCRIPTION
Tweaking stats and overhauling their weapon perks- guns aren't the only weapons that they're good with.

STATS
- Weaknesses are tweaked (-5% Physical, -5% Radiation and -20% Shadow)
- Cosmic resist is higher than before (30%)

WEAPONS
- Firearms nerfed to +5% Damage, +1% Crit
- Broadswords, Shortswords, Staves and Wands gain 5% damage
- Rapiers, Spears, Energy Weapons, Pistols and Machine Pistols gain 10% damage, +2% Crit

MISC
- More reformatting.