### PR TITLE
Solved doble update icon on quickbar

### DIFF
--- a/quickbar/icons.json.patch
+++ b/quickbar/icons.json.patch
@@ -9,20 +9,5 @@
 		"op": "add",
 		"path": "/normal/0",
 		"value": { "label" : "Character Status", "pane" : "/interface/scripted/statWindow/statWindow.config", "icon" : "/items/tools/inspectiontool/inspectionmode.png" }
-	}],
-	[{
-		"op" : "test",
-		"path" : "/normal/0/label",
-		"value" : "Updates",
-		"inverse" : true
-	},
-	  {
-	    "op": "add",
-	    "path": "/normal/-",
-	    "value": {
-	      "label": "Updates",
-	      "pane": "/zb/updateInfoWindow/updateInfoWindow.config",
-	      "icon": "/interface/quest.png"
-	    }
-	  }]	
+	}]
 ]


### PR DESCRIPTION
Frackin Races has no reason to add a "Updates" icon. That icon should be added only by FU or Ztarbound.