### PR TITLE
Refining Moogles

### DIFF
--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -4829,8 +4829,16 @@
 				"amount": -0.2
 			},
 			{
+				"stat": "iceResistance",
+				"amount": 0.3
+			},
+			{
+				"stat": "fireResistance",
+				"amount": -0.2
+			},
+			{
 				"stat": "electricResistance",
-				"amount": 0.2
+				"amount": 0.3
 			},
 			{
 				"stat": "cosmicResistance",
@@ -4838,11 +4846,7 @@
 			},
 			{
 				"stat": "shadowResistance",
-				"amount": -0.3
-			},
-			{
-				"stat": "radioactiveResistance",
-				"amount": 0.0
+				"amount": -0.2
 			},
 			{
 				"stat": "fuCharisma",
@@ -4851,7 +4855,6 @@
 		],
 		"weaponEffects": [{
 				"weapons": [
-					"broadsword",
 					"shortsword",
 					"staff",
 					"wand"
@@ -4864,7 +4867,6 @@
 			{
 				"weapons": [
 					"pistol",
-					"machinepistol",
 					"rapier",
 					"spear"
 				],
@@ -4884,7 +4886,7 @@
 				],
 				"stats": [{
 						"stat": "powerMultiplier",
-						"baseMultiplier": 1.05
+						"baseMultiplier": 1.1
 					},
 					{
 						"stat": "critChance",
@@ -4894,9 +4896,9 @@
 			}
 		],
 		"controlModifiers": {
-			"speedModifier": 1.1,
-			"airJumpModifier": 1.1,
-			"liquidForce": 40
+			"speedModifier": 1.15,
+			"airJumpModifier": 1.15,
+			"liquidForce": 20
 		},
 		"weaponScripts": [{
 			"script": "/scripts/fr_weaponscripts/freebonus.lua",

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -5,17 +5,17 @@
     },
     { "op": "replace", 
     "path" : "/charCreationTooltip/description" , 
-    "value" : "Adorable, fluffy, cosmic-attuned lagomorphic critters from a distant world of fantasy that have a pom-pom, bat wings and a thing for saying \"Kupo!\". They are usually expert machinists, but on occasion, they may become a knight or a mage instead.
+    "value" : "Adorable, fluffy, cosmic-attuned lagomorphic critters from a distant world of fantasy that have a pom-pom, bat-like wings, and a thing for saying \"Kupo!\". They are usually expert machinists, but on occasion, they may choose to become a knight or a mage instead.
     
     ^orange;Diet: Omnivore^reset;
-    ^red;-20% Life, -20% Physical, -30% Shadow Resistances^reset;
-    ^green;+20% Energy, +20% Electric, 30% Cosmic Resistances^reset;
+    ^green;+20% Energy, +30% Electric, Ice, Cosmic Resistances^reset;
+    ^red;-20% Life, -20% Physical, Fire, Shadow Resistances^reset;
     ^green;Adorable, Halved Fall Damage^reset;
-    ^cyan;Gliding, ^green;+10% Speed and Jump, ^red;Bad at swimming^reset;
-    ^magenta;Moogle Glide tech (Obtain in [C] Menu), Extra craftable mech body^reset;
+    ^cyan;Gliding, ^green;+15% Agility, ^red;Terrible swimmers^reset;
+    ^magenta;Moogle Glide tech (Obtain in [C] Menu), Extra craftable mech body (Built-In)^reset;
     ^yellow;Firearms gain ^green;+5% Damage, +1% Crit^reset;
-    ^yellow;Broadswords, Shortswords, Staves, and Wands gain ^green;+5% damage^reset;
-    ^yellow;Rapiers, Spears, Pistols and Machine Pistols gain ^green;+10% damage, +1% Crit^reset;
-    ^yellow;Energy Weapons gain ^green;+5% damage, +2% Crit^reset;"
+    ^yellow;Shortswords, Staves, and Wands gain ^green;+5% damage^reset;
+    ^yellow;Rapiers, Spears, and Pistols gain ^green;+10% damage, +1% Crit^reset;
+    ^yellow;Energy Weapons gain ^green;+10% damage, +2% Crit^reset;"
     }
 ]


### PR DESCRIPTION
Stats:
Base Agility Modifier: 10% → 15%
Swimming Agility Modifier: 1/3 → -1/3

Resistances:
Electric: 20% → 30%
Shadow: -30% → -20%
Ice: 0% → 30%
Fire: 0% → -20%

Weapons:
Machine Pistol and Broadsword: Perks Removed
Energy Weapon Damage: 5% → 10%