### PR TITLE
Reworked Moogles

### DIFF
--- a/scripts/raceEffects.config
+++ b/scripts/raceEffects.config
@@ -4839,12 +4839,16 @@
 				"amount": 1
 			},
 			{
+				"stat": "foodDelta",
+				"baseMultiplier": 1.06146
+			},
+			{
 				"stat": "maxHealth",
 				"baseMultiplier": 0.8
 			},
 			{
 				"stat": "maxEnergy",
-				"baseMultiplier": 1.2
+				"baseMultiplier": 1.1
 			},
 			{
 				"stat": "fallDamageMultiplier",
@@ -4864,7 +4868,7 @@
 			},
 			{
 				"stat": "electricResistance",
-				"amount": 0.3
+				"amount": 0.2
 			},
 			{
 				"stat": "cosmicResistance",
@@ -4872,11 +4876,19 @@
 			},
 			{
 				"stat": "shadowResistance",
-				"amount": -0.2
+				"amount": -0.4
 			},
 			{
 				"stat": "fuCharisma",
 				"amount": 10
+			},
+			{
+				"stat": "electricStatusImmunity",
+				"amount": 1
+			},
+			{
+				"stat": "fumudslowImmunity",
+				"amount": 1
 			}
 		],
 		"weaponEffects": [{
@@ -4892,8 +4904,8 @@
 			},
 			{
 				"weapons": [
+					"dagger",
 					"pistol",
-					"rapier",
 					"spear"
 				],
 				"stats": [{
@@ -4912,37 +4924,20 @@
 				],
 				"stats": [{
 						"stat": "powerMultiplier",
-						"baseMultiplier": 1.1
+						"baseMultiplier": 1.15
 					},
 					{
-						"stat": "critChance",
-						"amount": 2
+						"stat": "critDamage",
+						"amount": 0.1
 					}
 				]
 			}
 		],
 		"controlModifiers": {
-			"speedModifier": 1.15,
-			"airJumpModifier": 1.15,
+			"speedModifier": 1.1,
+			"airJumpModifier": 1.2,
 			"liquidForce": 20
 		},
-		"weaponScripts": [{
-			"script": "/scripts/fr_weaponscripts/freebonus.lua",
-			"contexts": [
-				"gun-init"
-			],
-			"args": {
-				"stats": [{
-						"stat": "powerMultiplier",
-						"amount": 0.05
-					},
-					{
-						"stat": "critChance",
-						"amount": 1
-					}
-				]
-			}
-		}],
 		"aerialEffect": {
 			//"fallStats": {
 			//	"controlParameters": {
@@ -4956,15 +4951,15 @@
 				"windLow": {
 					"speed": 70,
 					"controlModifiers": {
-						"speedModifier": 1.12,
-						"airJumpModifier": 1.12
+						"speedModifier": 1.15,
+						"airJumpModifier": 1.25
 					}
 				},
 				"windHigh": {
 					"speed": 7,
 					"controlModifiers": {
 						"speedModifier": 1.2,
-						"airJumpModifier": 1.2
+						"airJumpModifier": 1.3
 					}
 				}
 			}


### PR DESCRIPTION
BUFFS
- Status Immunities: Electrified, Mud Slow
- Energy weapons gain +15 damage, up from 10%

NERFS
- Removed generic firearm perks
- +10% Energy, down from +20%
- -40% Shadow Weakness, up from -20%
- +20% Electric Resist, down from +30%

TWEAKS
- Hunger drains slightly faster
- Energy weapons exchanged +1% crit chance for +10% crit damage
- +20% Jump/+10% Speed, instead of +15% Agility
- Exchanged rapier perk for dagger perk
- (Hopefully) fixed the wind agility effects