### PR TITLE
Update radienFoodBoost.lua

### DIFF
--- a/stats/bonuses/radienFoodBoost.lua
+++ b/stats/bonuses/radienFoodBoost.lua
@@ -52,7 +52,11 @@ end
 
 
 function update(dt)
-  self.foodValue = status.resourcePercentage("food")
+	if status.isResource("food")
+		self.foodValue = status.resourcePercentage("food")
+	else
+		self.foodValue=0.5
+	end
   
   self.armorTimer = self.armorTimer + 1
   


### PR DESCRIPTION
fix for radian food boost. it was running (somehow) on a character and was checking for the percentage of a nonexistent resource (food). defaults to 0.5 in this case, now