### PR TITLE
Fix lag with tricorder, fix potential double newlines in race desc, patch shield asset errors

### DIFF
--- a/interface/scripted/statWindow/extraStatsWindow.config
+++ b/interface/scripted/statWindow/extraStatsWindow.config
@@ -249,5 +249,5 @@
 	"tooltipCheckDelay" : 5,	//	How many scriptDelta ticks should pass before the GUI updates tooltips (this * scriptDelta = actual rate)
 	
 	"scripts" : ["/interface/scripted/statWindow/extraStatsWindow.lua"],
-	"scriptDelta" : 5
+	"scriptDelta" : 30
 }

--- a/interface/scripted/statWindow/extraStatsWindow.config
+++ b/interface/scripted/statWindow/extraStatsWindow.config
@@ -249,5 +249,5 @@
 	"tooltipCheckDelay" : 5,	//	How many scriptDelta ticks should pass before the GUI updates tooltips (this * scriptDelta = actual rate)
 	
 	"scripts" : ["/interface/scripted/statWindow/extraStatsWindow.lua"],
-	"scriptDelta" : 1
+	"scriptDelta" : 5
 }

--- a/interface/scripted/statWindow/extraStatsWindow.config
+++ b/interface/scripted/statWindow/extraStatsWindow.config
@@ -245,8 +245,8 @@
 	],
   
 	"defaultTooltip" : "Hover over a stat for its description",		//	default tooltip when nothing would be display
-	"tooltipLifespan" : 150,		//	How long will the tooltip remain when you stop hovering over something (this * tooltipCheckDelay * scriptDelta = actual rate)
-	"tooltipCheckDelay" : 150,	//	How many scriptDelta ticks should pass before the GUI updates tooltips (this * scriptDelta = actual rate)
+	"tooltipLifespan" : 1,		//	How long will the tooltip remain when you stop hovering over something (this * tooltipCheckDelay * scriptDelta = actual rate)
+	"tooltipCheckDelay" : 1,	//	How many scriptDelta ticks should pass before the GUI updates tooltips (this * scriptDelta = actual rate)
 	
 	"scripts" : ["/interface/scripted/statWindow/extraStatsWindow.lua"],
 	"scriptDelta" : 30

--- a/interface/scripted/statWindow/extraStatsWindow.config
+++ b/interface/scripted/statWindow/extraStatsWindow.config
@@ -245,8 +245,8 @@
 	],
   
 	"defaultTooltip" : "Hover over a stat for its description",		//	default tooltip when nothing would be display
-	"tooltipLifespan" : 5,		//	How long will the tooltip remain when you stop hovering over something (this * tooltipCheckDelay * scriptDelta = actual rate)
-	"tooltipCheckDelay" : 5,	//	How many scriptDelta ticks should pass before the GUI updates tooltips (this * scriptDelta = actual rate)
+	"tooltipLifespan" : 150,		//	How long will the tooltip remain when you stop hovering over something (this * tooltipCheckDelay * scriptDelta = actual rate)
+	"tooltipCheckDelay" : 150,	//	How many scriptDelta ticks should pass before the GUI updates tooltips (this * scriptDelta = actual rate)
 	
 	"scripts" : ["/interface/scripted/statWindow/extraStatsWindow.lua"],
 	"scriptDelta" : 30

--- a/interface/scripted/statWindow/extraStatsWindow.lua
+++ b/interface/scripted/statWindow/extraStatsWindow.lua
@@ -1,7 +1,3 @@
-
-
-
-
 function init()
 	self.data = root.assetJson("/interface/scripted/statWindow/extraStatsWindow.config")
 	canvas = widget.bindCanvas("tooltipHandler")
@@ -9,9 +5,10 @@ function init()
 	self.delayCounter = self.data.tooltipCheckDelay
 	
 	widget.setText("tooltip", self.data.defaultTooltip)
+	updateInterface()
 end
 
-function update()
+function updateInterface()
 	-- Breath calculated separetly
 	local breatRegen = status.stat("breathRegenerationRate")
 	local breathRate = status.stat("breathDepletionRate")
@@ -52,7 +49,9 @@ function update()
 			end
 		end
 	end
-	
+end
+
+function update()
 	if self.delayCounter == 0 then
 		self.delayCounter = self.data.tooltipLifespan
 		

--- a/interface/scripted/statWindow/extraStatsWindow.lua
+++ b/interface/scripted/statWindow/extraStatsWindow.lua
@@ -7,7 +7,7 @@ function init()
 	widget.setText("tooltip", self.data.defaultTooltip)
 end
 
-function updateInterface()
+function update()
 	-- Breath calculated separetly
 	local breatRegen = status.stat("breathRegenerationRate")
 	local breathRate = status.stat("breathDepletionRate")
@@ -48,10 +48,7 @@ function updateInterface()
 			end
 		end
 	end
-end
-
-function update()
-	updateInterface()
+	
 	if self.delayCounter == 0 then
 		self.delayCounter = self.data.tooltipLifespan
 		

--- a/interface/scripted/statWindow/extraStatsWindow.lua
+++ b/interface/scripted/statWindow/extraStatsWindow.lua
@@ -5,7 +5,6 @@ function init()
 	self.delayCounter = self.data.tooltipCheckDelay
 	
 	widget.setText("tooltip", self.data.defaultTooltip)
-	updateInterface()
 end
 
 function updateInterface()
@@ -52,6 +51,7 @@ function updateInterface()
 end
 
 function update()
+	updateInterface()
 	if self.delayCounter == 0 then
 		self.delayCounter = self.data.tooltipLifespan
 		

--- a/interface/scripted/statWindow/statWindow.config
+++ b/interface/scripted/statWindow/statWindow.config
@@ -265,5 +265,5 @@
 
 	"scriptWidgetCallbacks" : [ "expand" ],
 	"scripts" : ["/interface/scripted/statWindow/statWindow.lua"],
-	"scriptDelta" : 10
+	"scriptDelta" : 30
 }

--- a/interface/scripted/statWindow/statWindow.config
+++ b/interface/scripted/statWindow/statWindow.config
@@ -265,5 +265,5 @@
 
 	"scriptWidgetCallbacks" : [ "expand" ],
 	"scripts" : ["/interface/scripted/statWindow/statWindow.lua"],
-	"scriptDelta" : 1
+	"scriptDelta" : 10
 }

--- a/interface/scripted/statWindow/statWindow.lua
+++ b/interface/scripted/statWindow/statWindow.lua
@@ -1,5 +1,4 @@
-
---- THIS IS THE FRACKIN RACES ONE
+-- THIS IS THE FRACKIN RACES ONE
 
 function init()
 	self.data = root.assetJson("/interface/scripted/statWindow/statWindow.config")

--- a/interface/scripted/statWindow/statWindow.lua
+++ b/interface/scripted/statWindow/statWindow.lua
@@ -63,9 +63,11 @@ function populateRacialDescription(race)
 	widget.clearListItems("racialDesc.textList")
 	
 	local JSON = root.assetJson("/species/"..race..".species")
-	local charGenLabels = JSON.charGenTextLabels
-	local racialName = charGenLabels[#charGenLabels-1] --NOTE: In the species file there is the character generation label list. The second to last is the user-friendly display name of the race.
-	widget.setText("racialLabel", "RACIAL TRAITS - " .. racialName:upper()) --It's a standard that this name is all caps but in case someone didn't do that, we'll do it for them.
+	--local charGenLabels = JSON.charGenTextLabels
+	--local racialName = charGenLabels[#charGenLabels-1] --NOTE: In the species file there is the character generation label list. The second to last is the user-friendly display name of the race.
+	--Edit: Go with the character creation tooltip title.
+	local racialName = JSON.charCreationTooltip.title
+	widget.setText("racialLabel", "Racial Traits - " .. racialName)
 	
 	local str = JSON.charCreationTooltip.description
 	local strTbl = {}

--- a/interface/scripted/statWindow/statWindow.lua
+++ b/interface/scripted/statWindow/statWindow.lua
@@ -28,9 +28,11 @@ function init()
 	else
 		widget.setText("racialLabel", "ERROR - UNRECOGNIZED SPECIES")
 	end
+	
+	updateInterface()
 end
 
-function update()
+function updateInterface()
 	for _, element in ipairs(self.elements) do
 		widget.setText(element.."Resist", math.floor(status.stat(element.."Resistance")*100+0.5).."%")
 	end
@@ -55,6 +57,9 @@ function update()
 	end
 end
 
+function update()
+end
+
 function expand()
 	player.interact("ScriptPane", "/interface/scripted/statWindow/extraStatsWindow.config", player.id())
 end
@@ -72,6 +77,10 @@ function populateRacialDescription(race)
 	local skip = false
 	local firstskip = false
 	local char = ""
+	
+	--Some text editors use the windows line ending, like notepad++
+	--We need to normalize this to just use the unix style ending (\n), as Windows line endings are CRLF (\r\n) and cause double-newlines.
+	str = str:gsub("\r\n", "\n")
 	
 	for i = 1, string.len(str) do
 		char = string.sub(str, i, i)

--- a/interface/scripted/statWindow/statWindow.lua
+++ b/interface/scripted/statWindow/statWindow.lua
@@ -20,7 +20,7 @@ function init()
 	
 	if recognized then
 		widget.setImage("characterSuit", "/interface/scripted/techupgrade/suits/"..playerRace.."-"..player.gender()..".png")
-		widget.setText("racialLabel", "Racial traits - "..playerRace)
+		--widget.setText("racialLabel", "Racial traits - "..playerRace) --Moved into populateRacialDescription to get the friendly-text name.
 		widget.setVisible("racialDesc", true)
 		widget.setVisible("offline", false)
 		
@@ -28,11 +28,9 @@ function init()
 	else
 		widget.setText("racialLabel", "ERROR - UNRECOGNIZED SPECIES")
 	end
-	
-	updateInterface()
 end
 
-function updateInterface()
+function update()
 	for _, element in ipairs(self.elements) do
 		widget.setText(element.."Resist", math.floor(status.stat(element.."Resistance")*100+0.5).."%")
 	end
@@ -57,9 +55,6 @@ function updateInterface()
 	end
 end
 
-function update()
-end
-
 function expand()
 	player.interact("ScriptPane", "/interface/scripted/statWindow/extraStatsWindow.config", player.id())
 end
@@ -68,6 +63,10 @@ function populateRacialDescription(race)
 	widget.clearListItems("racialDesc.textList")
 	
 	local JSON = root.assetJson("/species/"..race..".species")
+	local charGenLabels = JSON.charGenTextLabels
+	local racialName = charGenLabels[#charGenLabels-1] --NOTE: In the species file there is the character generation label list. The second to last is the user-friendly display name of the race.
+	widget.setText("racialLabel", "RACIAL TRAITS - " .. racialName:upper()) --It's a standard that this name is all caps but in case someone didn't do that, we'll do it for them.
+	
 	local str = JSON.charCreationTooltip.description
 	local strTbl = {}
 	local splitters = {}

--- a/items/active/shields/shield.lua
+++ b/items/active/shields/shield.lua
@@ -12,7 +12,9 @@ function init()
 	self.active = false
 	self.cooldownTimer = config.getParameter("cooldownTime")
 	self.activeTimer = 0
-
+	
+	self.animationData = config.getParameter("animationCustom", {})
+	
 	self.level = config.getParameter("level", 1)
 	self.baseShieldHealth = config.getParameter("baseShieldHealth", 1)
 	self.knockback = config.getParameter("knockback", 0)
@@ -45,42 +47,42 @@ function init()
   
 	-- FU special effects
 	-- health effects
-	        self.critChance = config.getParameter("critChance", 0)
-	        self.critBonus = config.getParameter("critBonus", 0)
-	        self.shieldBonusShield = config.getParameter("shieldBonusShield", 0)	-- bonus shield HP
-	        self.shieldBonusRegen = config.getParameter("shieldBonusRegen", 0)	-- bonus shield regen time
- 		self.shieldHealthRegen = config.getParameter("shieldHealthRegen", 0)
- 		shieldStamina = config.getParameter("shieldStamina",0)
- 		protectionBee = config.getParameter("protectionBee",0)
- 		protectionAcid = config.getParameter("protectionAcid",0)
- 		protectionBlackTar = config.getParameter("protectionBlackTar",0)
- 		protectionBioooze = config.getParameter("protectionBioooze",0)
- 		protectionPoison = config.getParameter("protectionPoison",0)
- 		protectionInsanity = config.getParameter("protectionInsanity",0)
- 		protectionShock = config.getParameter("protectionShock",0)
- 		protectionSlime = config.getParameter("protectionSlime",0)
- 		protectionLava = config.getParameter("protectionLava",0)
- 		protectionFire = config.getParameter("protectionFire",0)
- 		protectionProto = config.getParameter("protectionProto",0)
- 		protectionAcid = config.getParameter("protectionAcid",0)
- 		protectionBlackTar = config.getParameter("protectionBlackTar",0)
- 		protectionBioooze = config.getParameter("protectionBioooze",0)
- 		protectionPoison = config.getParameter("protectionPoison",0)
- 		protectionInsanity = config.getParameter("protectionInsanity",0)
- 		protectionShock = config.getParameter("protectionShock",0)
- 		protectionSlime = config.getParameter("protectionSlime",0)
- 		protectionLava = config.getParameter("protectionLava",0)
- 		protectionFire = config.getParameter("protectionFire",0)
- 		protectionProto = config.getParameter("protectionProto",0)
- 		protectionCold = config.getParameter("protectionCold",0)
- 		protectionXCold = config.getParameter("protectionXCold",0)
- 		protectionHeat = config.getParameter("protectionHeat",0)
- 		protectionXHeat = config.getParameter("protectionXHeat",0)
- 		protectionRads = config.getParameter("protectionRads",0)
- 		protectionXRads = config.getParameter("protectionXRads",0)
- 		stunChance = config.getParameter("stunChance", 0)
- 		shieldBash = config.getParameter("shieldBash",0)
- 		shieldBashPush = config.getParameter("shieldBashPush",0)
+	self.critChance = config.getParameter("critChance", 0)
+	self.critBonus = config.getParameter("critBonus", 0)
+	self.shieldBonusShield = config.getParameter("shieldBonusShield", 0)	-- bonus shield HP
+	self.shieldBonusRegen = config.getParameter("shieldBonusRegen", 0)	-- bonus shield regen time
+	self.shieldHealthRegen = config.getParameter("shieldHealthRegen", 0)
+	shieldStamina = config.getParameter("shieldStamina",0)
+	protectionBee = config.getParameter("protectionBee",0)
+	protectionAcid = config.getParameter("protectionAcid",0)
+	protectionBlackTar = config.getParameter("protectionBlackTar",0)
+	protectionBioooze = config.getParameter("protectionBioooze",0)
+	protectionPoison = config.getParameter("protectionPoison",0)
+	protectionInsanity = config.getParameter("protectionInsanity",0)
+	protectionShock = config.getParameter("protectionShock",0)
+	protectionSlime = config.getParameter("protectionSlime",0)
+	protectionLava = config.getParameter("protectionLava",0)
+	protectionFire = config.getParameter("protectionFire",0)
+	protectionProto = config.getParameter("protectionProto",0)
+	protectionAcid = config.getParameter("protectionAcid",0)
+	protectionBlackTar = config.getParameter("protectionBlackTar",0)
+	protectionBioooze = config.getParameter("protectionBioooze",0)
+	protectionPoison = config.getParameter("protectionPoison",0)
+	protectionInsanity = config.getParameter("protectionInsanity",0)
+	protectionShock = config.getParameter("protectionShock",0)
+	protectionSlime = config.getParameter("protectionSlime",0)
+	protectionLava = config.getParameter("protectionLava",0)
+	protectionFire = config.getParameter("protectionFire",0)
+	protectionProto = config.getParameter("protectionProto",0)
+	protectionCold = config.getParameter("protectionCold",0)
+	protectionXCold = config.getParameter("protectionXCold",0)
+	protectionHeat = config.getParameter("protectionHeat",0)
+	protectionXHeat = config.getParameter("protectionXHeat",0)
+	protectionRads = config.getParameter("protectionRads",0)
+	protectionXRads = config.getParameter("protectionXRads",0)
+	stunChance = config.getParameter("stunChance", 0)
+	shieldBash = config.getParameter("shieldBash",0)
+	shieldBashPush = config.getParameter("shieldBashPush",0)
 
  	        --shieldBonusApply()
 	-- end FU special effects
@@ -99,7 +101,6 @@ end
 
 
 function shieldBonusApplyPartial()
-
 	status.setPersistentEffects("shieldEffects", {
  		{stat = "maxHealth", amount = config.getParameter("shieldHealthBonus",0)*(status.resourceMax("health"))},
  		{stat = "maxEnergy", amount = config.getParameter("shieldEnergyBonus",0)*(status.resourceMax("energy"))},
@@ -112,11 +113,9 @@ function shieldBonusApplyPartial()
  		{stat = "critChance", amount =  self.critChance},
  		{stat = "critChance", amount =  self.critBonus} 		
  	})
- 	
 end
 
 function shieldBonusApply()
-
 	status.setPersistentEffects("shieldEffects", {
  		{stat = "baseShieldHealth", amount = config.getParameter("shieldBonusShield", 0) },
  		{stat = "energyRegenPercentageRate", amount = config.getParameter("shieldEnergyRegen",0)},
@@ -153,7 +152,6 @@ function shieldBonusApply()
  		{stat = "shieldBash", amount = shieldBash},
  		{stat = "shieldBashPush", amount = shieldBashPush}
  	})
- 	
 end
 
 function isShield(name) -- detect if they have a shield equipped for racial tag checks
@@ -297,9 +295,13 @@ function raiseShield()
                     if (self.energyval) >= 50 and (self.randomBash) >= 50 then -- greater chance to Shield Bash when perfect blocking
                         bashEnemy()
                     end
-
-                    animator.playSound("perfectBlock")
-                    animator.burstParticleEmitter("perfectBlock")
+					
+					--No catch case for this sound since it's required by vanilla.
+					animator.playSound("perfectBlock")
+					
+					if self.animationData.particleEmitters and self.animationData.particleEmitters.perfectBlock then
+						animator.burstParticleEmitter("perfectBlock")
+					end
 
 
                     -- *******************************************************
@@ -365,8 +367,17 @@ function bashEnemy()
     local params = { speed=20, power = self.damageLimit , damageKind = "default", knockback = self.pushBack } -- Shield Bash
     world.spawnProjectile("fu_genericBlankProjectile",mcontroller.position(),activeItem.ownerEntityId(),{0,0},false,params)
     status.modifyResource("energy", self.energyValue * -0.2 )	-- consume energy
-    animator.playSound("shieldBash")
-    animator.burstParticleEmitter("shieldBashHit")
+	
+	if animator.hasSound("shieldBash") then
+		--Protection for if the user hasn't specified shield bash sounds
+		animator.playSound("shieldBash")
+	end
+
+	--Alright Bob I'll take "Slapping chucklefish for not offering animator.hasParticle" for $500.
+	if self.animationData.particleEmitters and self.animationData.particleEmitters.shieldBashHit then
+		--Protection for if the user hasn't specified shield bash partiles
+		animator.burstParticleEmitter("shieldBashHit")
+	end
 end
 
 function clearEffects()


### PR DESCRIPTION
Changes done to achieve this:
1) Increase scriptDelta to 10 (from 1)
2) Remove UI data population from update() since the data is static and this only wastes performance
3) `string:gsub("\r\n", "\n")` to remove windows line endings (CRLF) and replace them with standard line-feed endings.