### PR TITLE
Updates

### DIFF
--- a/species/moogle.raceeffect
+++ b/species/moogle.raceeffect
@@ -4,8 +4,8 @@
 			"amount": 1
 		},
 		{
-			"stat": "foodDelta",
-			"baseMultiplier": 1.06146
+			"stat": "maxFood",
+			"effectiveMultiplier": 0.8
 		},
 		{
 			"stat": "maxHealth",
@@ -89,7 +89,7 @@
 			],
 			"stats": [{
 					"stat": "powerMultiplier",
-					"baseMultiplier": 1.15
+					"effectiveMultiplier": 1.1
 				},
 				{
 					"stat": "critDamage",

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -19,7 +19,7 @@
     ^orange;Weapons^reset;:
     Shortswords, Staves, and Wands: ^green;+5%^reset; damage
     Pistols, Spears, and Daggers: ^green;+10%^reset; damage, ^green;+1%^reset; crit
-    Energy Weapons: ^green;+10%^reset; damage, +10%^reset; crit damage
+    Energy Weapons: ^green;+10%^reset; damage, ^green;+10%^reset; crit damage
  
     ^red;Weaknesses^reset;:   
     Terrible swimmers

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -12,18 +12,18 @@
     ^orange;Perks^reset;:
     ^green;+10%^reset; Energy, Charisma, Speed
     ^green;+20%^reset; Jump, ^green;-50%^reset; Fall Damage
-    ^green;+30%^reset; Cosmic/Ice Resist, ^green;+20%^reset; Electric Resist    
+    ^green;+30%^reset; Cosmic & Ice Resist, ^green;+20%^reset; Electric Resist    
     ^cyan;Moogle Glide tech (Obtain in [C] Menu)^reset;
     Immune: Electrified, Mud
  
     ^orange;Weapons^reset;:
     Shortswords, Staves, and Wands: ^green;+5%^reset; damage
     Pistols, Spears, and Daggers: ^green;+10%^reset; damage, ^green;+1%^reset; crit
-    Energy Weapons: ^green;+15%^reset; damage, +10%^reset; crit damage
+    Energy Weapons: ^green;+10%^reset; damage, +10%^reset; crit damage
  
     ^red;Weaknesses^reset;:   
     Terrible swimmers
-    ^red;-6%^reset; Faster Hunger Rate, 
+    ^red;-20%^reset; Max Food, 
     ^red;-20%^reset; Health,
     ^red;-40%^reset; Shadow Resist, ^red;-20%^reset; Fire & Physical Resist
 "

--- a/species/moogle.species.patch
+++ b/species/moogle.species.patch
@@ -23,8 +23,8 @@
  
     ^red;Weaknesses^reset;:   
     Terrible swimmers
-    ^red;-20%^reset; Max Food, 
-    ^red;-20%^reset; Health,
+    ^red;-20%^reset; Max Food
+    ^red;-20%^reset; Health
     ^red;-40%^reset; Shadow Resist, ^red;-20%^reset; Fire & Physical Resist
 "
     }


### PR DESCRIPTION
- Increased hunger drain replaced with lowered max hunger
- Energy weapon damage+ is tweaked (Nerfed to 10%, but applies as a multiplicative modifier, instead of a flat +15%)