### PR TITLE
Nerf Spirit Guardian's Jump

### DIFF
--- a/species/spiritguardian.raceeffect
+++ b/species/spiritguardian.raceeffect
@@ -16,7 +16,7 @@
 	],
 	"controlModifiers": {
 		"speedModifier": 1.20,
-		"airJumpModifier": 1.2
+		"airJumpModifier": 1.1
 	},
 	"envEffects": [
 		{

--- a/species/spiritguardian.species.patch
+++ b/species/spiritguardian.species.patch
@@ -10,7 +10,8 @@
 
 ^orange;Stats:^reset;
 ^red;-20% Health^reset;
-^green;+20% Energy, Speed, and Jump Height^reset;
+^green;+10% Jump Height
+^green;+20% Energy and Speed^reset;
 ^green;-20% Metabolism^reset;
 ^green;-40% Falling Damage^reset;
 


### PR DESCRIPTION
Because, looking back to when I made the original FR patch, a 20% jump height boost wasn't my brightest idea.
As in, I keep hitting my head against the ceiling trying to escape a pool of water in the first cave.