### PR TITLE
Support for Inkling mod planet type

### DIFF
--- a/species/inkling.raceeffect
+++ b/species/inkling.raceeffect
@@ -53,7 +53,9 @@
 	"envEffects": [{
 			"biomes": [
 				"ocean",
-				"oceanfloor"
+				"oceanfloor",
+				"flooded",
+                                "floodedoceanfloor"
 			],
 			"stats": [{
 					"stat": "maxHealth",


### PR DESCRIPTION
Added "flooded" and "floodedoceanfloor" biomes to the infinite oxygen buffs and effects. 
Flooded planets are essentially an alternate Oceanic planet found in the Inkling species mod, meant to be where they natively live, so it makes logical sense.

Might remove this change later on if I ever merge Flooded planet changes back with official Oceanic planets, but it's not planned currently.