### PR TITLE
Spirit Guardians => 100% Fall Resistance

### DIFF
--- a/species/spiritguardian.raceeffect
+++ b/species/spiritguardian.raceeffect
@@ -11,7 +11,7 @@
 		{ "stat": "cosmicResistance", "amount": 0.1 },
 		{ "stat": "jungleslowImmunity", "amount": 1 },
 		{ "stat": "fumudslowImmunity", "amount": 1 },
-		{ "stat": "fallDamageMultiplier", "baseMultiplier": 0.6 }
+		{ "stat": "fallDamageMultiplier", "baseMultiplier": 0 }
 	],
 	"diet" : "herbivore",
 	"controlModifiers": {

--- a/species/spiritguardian.species.patch
+++ b/species/spiritguardian.species.patch
@@ -12,7 +12,7 @@
 ^red;-20% Health^reset;
 ^green;+20% Energy, Speed, and Jump Height^reset;
 ^green;-20% Metabolism^reset;
-^green;-40% Falling Damage^reset;
+^green;-100% Falling Damage^reset;
 
 ^orange;Resistances:^reset;
 ^red;-30% Physical, Poison^reset;


### PR DESCRIPTION
This is a relatively extreme change but after consideration I have dubbed it a fair addition.

The primary factors of this decision came from looking at Starbound world and combat mechanics as well as the race's current stats.

The race is designed for extreme mobility at the cost of physical resistances. Most if not all pit traps in Starbound contain spikes or some other hazard at the bottom. The only immediate location this may grant the player benefits over others is in PvP where one player may launch another off of a cliff; this race will survive where any other player would have died.