### PR TITLE
Fixed some compatibility issues due to an improperly formatted file

### DIFF
--- a/species/remorian.raceeffect
+++ b/species/remorian.raceeffect
@@ -1,138 +1,102 @@
 {
 	"stats": [
-		{
-			"stat": "maxHealth",
-			"baseMultiplier": 0.95
-		},
-		{
-			"stat": "protection",
-			"effectiveMultiplier": 0.9
-		},
-		{
-			"stat": "maxEnergy",
-			"baseMultiplier": 1.1
-		},
-		{
-			"stat": "maxBreath",
-			"amount": 1500
-		},
-		{
-			"stat": "foodDelta",
-			"baseMultiplier": 1.05
-		},
-		{
-			"stat": "powerMultiplier",
-			"baseMultiplier": 1.05
-		},
-		{
-			"stat": "electricResistance",
-			"amount": -0.3
-		},
-		{
-			"stat": "fireResistance",
-			"amount": 0.0
-		},
-		{
-			"stat": "iceResistance",
-			"amount": 0.1
-		},
-		{
-			"stat": "shadowResistance",
-			"amount": 0.20
-		},
-		{
-			"stat": "radioactiveResistance",
-			"amount": -0.2
-		},
-		{
-			"stat": "wetImmunity",
-			"amount": 1
-		},
-		{
-			"stat": "energyRegenPercentageRate",
-			"baseMultiplier": 1.15
-		}
+		{ "stat": "maxHealth", "effectiveMultiplier": 0.95 },
+		{ "stat": "protection", "effectiveMultiplier": 0.9 },
+		{ "stat": "maxEnergy", "effectiveMultiplier": 1.1 },
+		{ "stat": "powerMultiplier", "effectiveMultiplier": 1.05 },
+		{ "stat": "foodDelta", "baseMultiplier": 1.05 },
+		{ "stat": "maxBreath", "amount": 1500 },
+		{ "stat": "electricResistance", "amount": -0.3 },
+		{ "stat": "iceResistance", "amount": 0.1 },
+		{ "stat": "shadowResistance", "amount": 0.2 },
+		{ "stat": "radioactiveResistance", "amount": -0.2 }
 	],
 	"diet" : "omnivore",
 	"controlModifiers": {
-		"speedModifier": 1.1
+		"speedModifier": 1.05
 	},
+	"envEffects": [
+		{
+			"biomes": [ "ocean", "oceanfloor", "flooded", "floodedoceanfloor", "arctic", "arcticdark", "tidewater" ],
+			"stats": [
+				{ "stat": "maxHealth", "effectiveMultiplier": 1.05 },
+				{ "stat": "maxEnergy", "effectiveMultiplier": 1.1 },
+				{ "stat": "energyRegenPercentageRate", "effectiveMultiplier": 1.15 }
+			],
+			"controlModifiers": {
+				"speedModifier": 1.2	
+			}
+		},
+		{
+			"biomes": [ "jungle", "penumbra", "bog", "rainforest" ],
+			"stats": [
+				{ "stat": "maxEnergy", "effectiveMultiplier": 1.05 }
+			]
+		},
+		{
+			"biomes": [ "scorchedcity", "desert", "desertwastes", "desertwastesdark", "magma", "magmadark", "volcanic", "volcanicdark" ],
+			"stats": [
+				{ "stat": "maxEnergy", "effectiveMultiplier": 0.85 },
+				{ "stat": "maxHealth", "effectiveMultiplier": 0.85 },
+				{ "stat": "energyRegenPercentageRate", "effectiveMultiplier": 0.7 }
+			]
+		}
+	],
 	"weaponEffects": [
 		{
-			"weapons": [ "shortspear", "spear" ],
+			"weapons": [ "broadsword", "shortsword", "dagger" ],
 			"stats": [
-				{
-					"stat": "powerMultiplier",
-					"baseMultiplier": 1.1
-				},
-				{
-					"stat": "protection",
-					"effectiveMultiplier": 1.15
-				}
+				{ "stat": "powerMultiplier", "effectiveMultiplier": 1.15 },
+				{ "stat": "critChance", "amount": 5 }
+			]
+		},
+		{
+			"weapons": [ "shortspear", "spear", "quarterstaff" ],
+			"stats": [
+				{ "stat": "powerMultiplier", "effectiveMultiplier": 1.1 },
+				{ "stat": "protection", "effectiveMultiplier": 1.1 }
 			]
 		},
 		{
 			"weapons": [ "wand", "staff" ],
 			"stats": [
-				{
-					"stat": "powerMultiplier",
-					"baseMultiplier": 1.08
-				},
-				{
-					"stat": "maxEnergy",
-					"baseMultiplier": 1.08
-				}
+				{ "stat": "powerMultiplier", "effectiveMultiplier": 1.08 },
+				{ "stat": "maxEnergy", "effectiveMultiplier": 1.08 }
 			]
 		},
 		{
-			"weapons": [ "broadsword", "shortsword", "dagger" ],
+			"combos": [ [ "dagger", "dagger" ] ],
 			"stats": [
-				{
-					"stat": "powerMultiplier",
-					"baseMultiplier": 1.15
-				},
-				{
-					"stat": "critChance",
-					"amount": 5
-				}
-			]
+				{ "stat": "critChance", "amount": 8 },
+				{ "stat": "critDamage", "amount": 0.25 }
+			],
+			"controlModifiers": {
+				"speedModifier": 1.08
+			}
+		},
+		{
+			"combos": [
+				[ "shortsword", "shield" ]
+			],
+			"stats": [
+				{ "stat": "protection", "amount": 6 }
+			],
+			"controlModifiers": {
+				"speedModifier": 0.9
+			}
 		}
 	],
-	"special": {
+	"special": [
 		"swimboost2"
 	],
-	"envEffects": [
+	"liquidEffects": [
 		{
-			"biomes": [ "scorchedcity", "desert", "desertwastes", "desertwastesdark", "magma", "magmadark", "volcanic", "volcanicdark" ],
-			"stats": [{
-					"stat": "maxEnergy",
-					"baseMultiplier": 0.85
-				},
-				{
-					"stat": "maxHealth",
-					"baseMultiplier": 0.85
-				},
-				{
-					"stat": "energyRegenPercentageRate",
-					"baseMultiplier": 0.70
-				}]
-		},
-		{
-			"biomes": [ "jungle", "penumbra", "bog", "rainforest" ],
-			"stats": [{
-					"stat": "maxEnergy",
-					"baseMultiplier": 1.05
-			}]
-		},
-		{
-			"biomes": [ "ocean", "oceanfloor", "flooded", "floodedoceanfloor", "arctic", "arcticdark", "tidewater" ],
-			"stats": [{
-					"stat": "maxEnergy",
-					"baseMultiplier": 1.1
-				}],
-				"controlModifiers": {
-					"speedModifier": 1.2
-				}
+			"liquids": [ "water", "healingwater", "wastewater", "swampwater" ],
+			"stats": [
+				{ "stat": "maxEnergy", "effectiveMultiplier": 1.35 }
+			],
+			"statusEffects": [
+				"regenerationminor"
 			]
 		}
 	]

--- a/species/remorian.species.patch
+++ b/species/remorian.species.patch
@@ -5,24 +5,24 @@
     },
     { "op": "replace", 
     "path" : "/charCreationTooltip/description" , 
-    "value" : "The Remorian are a species of aquatic dragonoid people with an aptitude for magical energy. They tend to be somewhat more feeble physically than other races, but make up for it in their magical potential, which they draw from the ocean and other humid environments.
+    "value" : "The Remorian are a species of aquatic dragonoid people that draw energy from the ocean and other humid environments.
 
 Diet: Omnivore
 
 ^orange;Perks^reset;:
-^green;+10%^reset; Energy, ^green;+5%^reset; Damage, ^green;+10%^reset; Speed, ^green;+15%^reset; Energy Regen, ^green;+20%^reset; Shadow Resist, ^green;+10%^reset; Ice Resist, Wet Immunity, ^green;1500^reset; Breath, ^green;Swim Boost 2^reset;
+^green;+10%^reset; Energy, ^green;+5%^reset; Damage, ^green;+5%^reset; Speed, ^green;+15%^reset; Energy Regen, ^green;+20%^reset; Shadow Resist, ^green;+10%^reset; Ice Resist, ^green;1500^reset; Breath, ^green;Swim Boost 2^reset;, ^green;+35% Max Energy^reset; and ^green;Minor Regeneration^reset; while submerged in ^orange;Water^reset;, ^orange;Healing Water^reset;, ^orange;Waste Water^reset;, or ^orange;Swamp Water^reset;
 ^red;Weaknesses^reset;:
 ^red;-5%^reset; Health, ^red;-10%^reset; Protection, ^red;+5%^reset; Hunger Rate, ^red;-20%^reset; Radioactivity, ^red;-30%^reset; Electricity
- 
 ^orange;Environment^reset;:
-Oceanic / Wet Biomes: ^green;+10% Max Energy^reset; ^green;+20% Speed^reset;
+Oceanic / Wet Biomes: ^green;+10% Max Energy^reset; ^green;+5% Max Health^reset; ^green;+15% Energy Regen^reset; ^green;+20% Speed^reset;
 Jungle / Humid Biomes: ^green;+5% Max Energy^reset;
 Hot / Dry Biomes: ^red;-15% Max Energy^reset; ^red;-15% Max Health^reset; ^red;-30% Energy Regen^reset;
- 
 ^orange;Weapons^reset;:
-Shortspear / Spear: ^green;+10%^reset; Damage, ^green;+15%^reset; Protection
-Wands / Staves: ^green;8%^reset; Damage and Energy
+Shortspear / Spear / Quarterstaff: ^green;+10%^reset; Damage, ^green;+10%^reset; Protection
+Wands / Staves: ^green;8%^reset; Damage and Max Energy
 Broadswords / Shortswords / Daggers: ^green;+15%^reset; Damage, ^green;+5%^reset; Critical Chance
+Dual Wield Daggers: ^green;+8%^reset; Critical Chance, ^green;+25%^reset; Critical Damage, ^green;+8%^reset; Speed
+Shortsword + Shield: ^green;+6^reset; Protection, ^red;-10%^reset; Speed
 Playstyle: ^yellow;Fighting^reset;
 "
     }


### PR DESCRIPTION
FR species perks for the Remorian mod stopped working after the last pull request, so I remade the .raceeffect file from scratch and added a few new perks to go along with it. Changes made involve:

-Changed speed modifier from +10% to +5%
-Removed wet immunity
-Added +5% max health and +15% energy regen for ocean/wet biomes
-Added quarterstaff to spear/shortspear bonus
-Added 2 dagger combo which adds +8% crit chance, +25% crit damage, and +8% speed
-Added shortsword and shield combo which adds +6 protection and -10% speed
-Added +35% max energy and minor regen when submerged in water, healing water, waste water, or swamp water