### PR TITLE
Shortening the racial blurb for the Lutrin

### DIFF
--- a/species/lutrin.species.patch
+++ b/species/lutrin.species.patch
@@ -5,17 +5,16 @@
     },
     { "op": "replace",
     "path" : "/charCreationTooltip/description" ,
-    "value" : "Enemies-turned-allies of the Hylotl, these massive otters can prove a formidable opponent in the water, though they are not ones to be trifled with on land, either. You know how the Hylotl have an honored warrior tradition? These guys are partially to blame for why that's so pronounced; the two races have a rather rocky history with each other. Mind you, neither are they too fond of the Florans, and for the same reason, no less...
+    "value" : "Enemies-turned-allies of the Hylotl, these massive otters can prove a formidable opponent in the water, though they are not ones to be trifled with on land, either.
 
-Diet: Semi-Carnivore, and the fresher the food, the better... for the most part. Fruits are on the menu for them, though their best bonuses still come from fresh animal products.
+^orange;Diet^reset;: Semi-Carnivore, and the fresher the food, the better... for the most part. They can handle fruits, they just won't get any bonuses as a result.
 
 ^orange;Perks^reset;:
-(Built-In) ^orange;Large Profile^reset; (5 blocks tall).
+(Built-In) ^orange;Large Profile^reset; (5 blocks tall). You may have to force the untransforming at times, as a heads-up. Just hold the tech key and it'll do it.
 ^green;+20%^reset; health, ^green;+10%^reset; Power, ^green;+10%^reset; Protection, ^green;2000^reset; Breath, ^green;+100%^reset; breath regen
 ^green;+50% Max Food^reset;
 Immune: Wet
 ^green;No^reset; fall damage when submerged.
-Note: you'll have to force the un-morphing in the Vanilla Apex story mission in order to progress at one point. Just keep holding the tech key to do so.
 
 ^orange;Environment^reset;:
 Gain ^green;+10%^reset;, ^green;+15%^reset; or ^green;+20%^reset; additional strength and energy and drop the speed penalty in ^cyan;watery^reset;, ^blue;riverine^reset;, or ^indigo;oceanic^reset; biomes, respectively. Additionally, you gain an additional ^green;5%^reset; speed buff in the last of those three biome types.


### PR DESCRIPTION
Before, you couldn't see all of the stats due to the blurb getting in the way. Now, you can see all the stats. hopefully. Edit this pull request if you need to so that the stats can be seen.