### PR TITLE
Remove mental protection stat

### DIFF
--- a/species/spiritguardian.species.patch
+++ b/species/spiritguardian.species.patch
@@ -20,7 +20,6 @@
 ^green;+10% Ice^reset;
 ^red;-23% Poison, Radioactive, Electric, Fire^reset;
 ^red;-15% Physical^reset;
-^red;-10% Mental Protection ^#666666;(Go insane 10% faster)^reset;
 
 ^orange;Enviornmental Bonuses:^reset;
 ^yellow;Jungle, Forest, Bog, Arboreal:^reset; ^green;+15% Protection, +10% Health^reset;

--- a/species/spiritguardian.species.patch
+++ b/species/spiritguardian.species.patch
@@ -12,6 +12,7 @@
 ^green;+20% Move Speed, Jump Height^reset;
 ^green;+30% Energy^reset;
 ^green;+10% Metabolism ^#666666;(Hunger Decreases 10% Slower)^reset;
+^green;Passive Health Regeneration (Slow)^reset;
 ^red;-20% Max Health^reset;
 ^red;-20% Stomach Size^reset;
 


### PR DESCRIPTION
This stat is listed incorrectly in the species patch. It is not in the current .raceeffect file.