### PR TITLE
Kemono perfect block bonus fixes

### DIFF
--- a/species/kemono.raceeffect
+++ b/species/kemono.raceeffect
@@ -61,7 +61,7 @@
 			"args": {
 				"stats": [{
 						"stat": "powerMultiplier",
-						"baseMultiplier": 0.02
+						"baseMultiplier": 1.02
 					},
 					{
 						"stat": "protection",
@@ -71,7 +71,7 @@
 				"statCombos": {
 					"powerMultiplier": {
 						"comboBase": 0.02,
-						"max": 0.3
+						"max": 1.3
 					},
 					"protection": {
 						"comboBase": 2,


### PR DESCRIPTION
Makes perfect blocks increase damage appropiately and gives it the intended max bonus.